### PR TITLE
Remove `mod` and `env`

### DIFF
--- a/src/lager2json.app.src
+++ b/src/lager2json.app.src
@@ -5,8 +5,6 @@
   {applications, [
     kernel, stdlib, jsx, rfc3339
   ]},
-  {env, []},
-  {mod, []},
   {maintainers, ["@talentdeficit"]},
   {licenses, ["MIT", "Apache 2.0"]},
   {links, [{"Github", "https://github.com/talentdeficit/lager2json"}]}


### PR DESCRIPTION
`mod` is not required if the application doesn’t
start anything (other than it’s dependencies).
This was also causing issues when packing to a
release using `relx`:

```
===> Errors generating release
          lager2json: Missing parameter in .app file: mod
```